### PR TITLE
feat: update svg-to-ts to 8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@angular-devkit/core": "13.3.9",
         "@angular-devkit/schematics": "13.3.9",
         "@schematics/angular": "13.3.11",
-        "svg-to-ts": "^7.1.0",
-        "typescript": "4.6.4"
+        "svg-to-ts": "^8.0.0",
+        "typescript": "4.9.4"
       },
       "devDependencies": {
         "@angular-devkit/architect": "0.1303.9",
@@ -13956,9 +13956,9 @@
       }
     },
     "node_modules/svg-to-ts": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/svg-to-ts/-/svg-to-ts-7.1.1.tgz",
-      "integrity": "sha512-sV8UhtYAQokdTWVtjcFUuXAY3ZFQjnH9fYFijPVeM2VZ2jj1B0am6fJO+F6NNb7cv7iHop9cJYTakuaFSJ6CIQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/svg-to-ts/-/svg-to-ts-8.9.0.tgz",
+      "integrity": "sha512-3i2R31p7Iqdo0pRYGSDXz8JqxKgNSZnss1coiKEsnLqzP0IrDP0RnArtQYt3EdDrZe0YeJamIvVCd3nFoRcftg==",
       "dependencies": {
         "chalk": "^3.0.0",
         "commander": "^4.0.1",
@@ -13974,8 +13974,9 @@
         "typescript": "^3.7.2"
       },
       "bin": {
-        "svg-to-ts": "src/bin/svg-to-ts.js",
-        "svgtots": "src/bin/svg-to-ts.js"
+        "svg-to-ts-constants": "src/bin/svg-to-ts-constants.js",
+        "svg-to-ts-files": "src/bin/svg-to-ts-files.js",
+        "svg-to-ts-object": "src/bin/svg-to-ts-object.js"
       }
     },
     "node_modules/svg-to-ts/node_modules/chalk": {
@@ -14463,9 +14464,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -25439,9 +25440,9 @@
       }
     },
     "svg-to-ts": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/svg-to-ts/-/svg-to-ts-7.1.1.tgz",
-      "integrity": "sha512-sV8UhtYAQokdTWVtjcFUuXAY3ZFQjnH9fYFijPVeM2VZ2jj1B0am6fJO+F6NNb7cv7iHop9cJYTakuaFSJ6CIQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/svg-to-ts/-/svg-to-ts-8.9.0.tgz",
+      "integrity": "sha512-3i2R31p7Iqdo0pRYGSDXz8JqxKgNSZnss1coiKEsnLqzP0IrDP0RnArtQYt3EdDrZe0YeJamIvVCd3nFoRcftg==",
       "requires": {
         "chalk": "^3.0.0",
         "commander": "^4.0.1",
@@ -25811,9 +25812,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular-devkit/core": "13.3.9",
     "@angular-devkit/schematics": "13.3.9",
     "@schematics/angular": "13.3.11",
-    "svg-to-ts": "^7.1.0",
-    "typescript": "4.6.4"
+    "svg-to-ts": "^8.0.0",
+    "typescript": "4.9.4"
   },
   "devDependencies": {
     "@angular-devkit/architect": "0.1303.9",

--- a/svg-icons-builder/constants/index.ts
+++ b/svg-icons-builder/constants/index.ts
@@ -1,15 +1,17 @@
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
-import { ConstantsConversionOptions, ConversionType, convertToConstants, mergeWithDefaults } from 'svg-to-ts';
+import { ConstantsConversionOptions, convertToConstants, mergeWithDefaults } from 'svg-to-ts';
 
-interface Options extends ConstantsConversionOptions {}
+interface Options extends ConstantsConversionOptions {
+  conversionType: string
+}
 
 // Using `Options & JsonObject` instead of extending JsonObject because of optional boolean
 export default createBuilder<Options & JsonObject>((options: Options, context: BuilderContext) => {
   return new Promise<BuilderOutput>(async (resolve, reject) => {
     try {
-      if (options.conversionType !== ConversionType.CONSTANTS) {
-        reject(new Error(`This builder only supports '${ConversionType.CONSTANTS}' conversionType.`));
+      if (options.conversionType !== 'constants') {
+        reject(new Error(`This builder only supports constants conversionType.`));
       }
 
       const conversionOptions = await mergeWithDefaults(options);

--- a/svg-icons-builder/files/index.ts
+++ b/svg-icons-builder/files/index.ts
@@ -1,20 +1,22 @@
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
-import { ConversionType, FileConversionOptions, convertToFiles, mergeWithDefaults } from 'svg-to-ts';
+import {  FilesConversionOptions, convertToFiles, mergeWithDefaults } from 'svg-to-ts';
 
-interface Options extends FileConversionOptions {}
+interface Options extends FilesConversionOptions {
+  conversionType: string
+}
 
 // Using `Options & JsonObject` instead of extending JsonObject because of optional boolean
 export default createBuilder<Options & JsonObject>((options: Options, context: BuilderContext) => {
   return new Promise<BuilderOutput>(async (resolve, reject) => {
     try {
-      if (options.conversionType !== ConversionType.FILES) {
-        reject(new Error(`This builder only supports '${ConversionType.FILES}' conversionType.`));
+      if (options.conversionType !== 'files') {
+        reject(new Error(`This builder only supports files conversionType.`));
       }
 
       const conversionOptions = await mergeWithDefaults(options);
       context.logger.info('We are using the conversion type "files"');
-      await convertToFiles((conversionOptions as unknown) as FileConversionOptions);
+      await convertToFiles((conversionOptions as unknown) as FilesConversionOptions);
 
       resolve({ success: true });
       context.reportStatus(`Done.`);

--- a/svg-icons-builder/object/index.ts
+++ b/svg-icons-builder/object/index.ts
@@ -1,18 +1,19 @@
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
-import { JsonObject } from '@angular-devkit/core';
-import { ConversionType, ObjectConversionOptions, convertToSingleObject, mergeWithDefaults } from 'svg-to-ts';
+import { ObjectConversionOptions, convertToSingleObject, mergeWithDefaults } from 'svg-to-ts';
 
-interface Options extends ObjectConversionOptions, JsonObject {}
+interface Options extends ObjectConversionOptions {
+  conversionType: string
+}
 
 export default createBuilder<Options>((options: Options, context: BuilderContext) => {
   return new Promise<BuilderOutput>(async (resolve, reject) => {
     try {
-      if (options.conversionType !== ConversionType.OBJECT) {
-        reject(new Error(`This builder only supports '${ConversionType.OBJECT}' conversionType.`));
+      if (options.conversionType !== 'object') {
+        reject(new Error(`This builder only supports object conversionType.`));
       }
 
       const conversionOptions = await mergeWithDefaults(options);
-      if (conversionOptions.conversionType === ConversionType.OBJECT) {
+      if (conversionOptions.conversionType === 'object') {
         context.logger.info('We are using the conversion type "object"');
         await convertToSingleObject(conversionOptions);
       }

--- a/svg-icons-builder/test-helpers.ts
+++ b/svg-icons-builder/test-helpers.ts
@@ -1,7 +1,6 @@
-import { CommonConversionOptions } from 'svg-to-ts';
 import { Delimiter } from 'svg-to-ts/src/lib/generators/code-snippet-generators';
 
-export const defaultCommonOptions = (): CommonConversionOptions => ({
+export const defaultCommonOptions = () => ({
   srcFiles: ['./dinosaur-icons/icons/**/*.svg'],
   outputDirectory: './dist/test/dinosaur-icons',
   delimiter: Delimiter.CAMEL,


### PR DESCRIPTION
PR to update svg-to-ts to 8.0 

While updating I see there are some breaking changes, I see mergeWithDefaults is not exposed anymore.

@kreuzerk can we expose the API again or its not needed anymore?